### PR TITLE
Basic GoLang Flood Fill Algorithm Implementation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2020, Recluse Games
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+# floodfill
+A generic go-lang flood fill algorithm implementation 

--- a/examples/generic/grid.go
+++ b/examples/generic/grid.go
@@ -1,0 +1,15 @@
+package generic
+
+import "github.com/recluse-games/flood/pkg/flood"
+
+type GenericGrid struct {
+	nodes [][]flood.Node
+}
+
+func (n GenericGrid) Nodes() [][]flood.Node {
+	return n.nodes
+}
+
+func (n GenericGrid) SetNode(x int, y int, node flood.Node) {
+	n.nodes[x][y] = node
+}

--- a/examples/generic/main.go
+++ b/examples/generic/main.go
@@ -1,0 +1,32 @@
+package generic
+
+import "github.com/recluse-games/flood/pkg/flood"
+
+func main() {
+	grid := GenericGrid{}
+	nodes := make([][]flood.Node, 10)
+
+	// Generate an empty 10x10 grid of nodes
+	for x := 0; x < 10; x++ {
+		row := make([]flood.Node, 10)
+
+		for y := 0; y < 10; y++ {
+			node := GenericNode{}
+			node.SetPoint(flood.Point{X: x, Y: y})
+			node.SetID("0000")
+
+			row[y] = &node
+		}
+
+		nodes[x] = row
+	}
+
+	// Create a new flood instance with an origin point and max taxi-cab distance to fill to.
+	filler := flood.NewFiller(flood.Point{X: 0, Y: 0}, grid, 8)
+
+	// Fill the grid
+	filler.Fill(flood.Point{X: 0, Y: 0}, "0001", "0002")
+
+	// Return your now filled in nodes
+	filler.Grid.Nodes()[0][0].ID()
+}

--- a/examples/generic/node.go
+++ b/examples/generic/node.go
@@ -1,0 +1,35 @@
+package generic
+
+import "github.com/recluse-games/flood/pkg/flood"
+
+type GenericNode struct {
+	id    string
+	point flood.Point
+}
+
+func (n *GenericNode) ID() string {
+	return n.id
+}
+
+func (n *GenericNode) SetID(id string) {
+	n.id = id
+}
+
+func (n *GenericNode) Point() flood.Point {
+	return n.point
+}
+
+func (n *GenericNode) SetPoint(point flood.Point) {
+	n.point = point
+}
+
+func (n *GenericNode) Clone() flood.Node {
+	nodeCopy := GenericNode{
+		id:    n.id,
+		point: n.point,
+	}
+
+	typeCastedNode := nodeCopy
+
+	return &typeCastedNode
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/recluse-games/flood
+
+go 1.14

--- a/pkg/flood/direction.go
+++ b/pkg/flood/direction.go
@@ -12,7 +12,7 @@ const (
 
 // String returns the string representation of a direction.
 func (d Direction) String() string {
-	return [...]string{"Nort", "South", "East", "West"}[d]
+	return [...]string{"North", "South", "East", "West"}[d]
 }
 
 // Int returns the integer representation of a direction.

--- a/pkg/flood/direction.go
+++ b/pkg/flood/direction.go
@@ -1,0 +1,21 @@
+package flood
+
+// Direction an integer value that represents a cardinal direction
+type Direction int
+
+const (
+	North Direction = iota
+	East
+	South
+	West
+)
+
+// String returns the string representation of a direction.
+func (d Direction) String() string {
+	return [...]string{"Nort", "South", "East", "West"}[d]
+}
+
+// Int returns the integer representation of a direction.
+func (d Direction) Int() int {
+	return [...]int{0, 1, 2, 3}[d]
+}

--- a/pkg/flood/filler.go
+++ b/pkg/flood/filler.go
@@ -1,0 +1,56 @@
+package flood
+
+// Directions A slice representing the four cardinal directions.
+var Directions = []Direction{North, South, East, West}
+
+// Filler flood fills a board state
+type Filler struct {
+	Origin      Point
+	Grid        Grid
+	MaxDistance int
+}
+
+// NewFiller Returns a new instance of Filler
+func NewFiller(origin Point, grid Grid, maxDistance int) *Filler {
+	return &Filler{origin, grid, maxDistance}
+}
+
+// Fill Runs FloodFill algorithm for a grid based on starting coordinates and IDs for fillage and blockage.
+func (f *Filler) Fill(point Point, filledID string, blockedID string) {
+	node := f.Grid.Nodes()[point.X][point.Y].Clone()
+
+	if node.ID() != filledID && node.ID() != blockedID && f.validateDistance(point) {
+		node.SetID(filledID)
+		f.Grid.SetNode(point.X, point.Y, node)
+
+		for direction := range Directions {
+			switch direction {
+			case North.Int():
+				if point.Y+1 < len(f.Grid.Nodes()[point.X]) {
+					f.Fill(Point{point.X, point.Y + 1}, filledID, blockedID)
+				}
+			case South.Int():
+				if 0 < point.Y-1 {
+					f.Fill(Point{point.X, point.Y - 1}, filledID, blockedID)
+				}
+			case East.Int():
+				if point.X+1 < len(f.Grid.Nodes()) {
+					f.Fill(Point{point.X + 1, point.Y}, filledID, blockedID)
+				}
+			case West.Int():
+				if 0 < point.X-1 {
+					f.Fill(Point{point.X - 1, point.Y}, filledID, blockedID)
+				}
+			}
+		}
+	}
+}
+
+// validateDistance Validates that the distance between two points is above the MaxDistance
+func (f *Filler) validateDistance(point Point) bool {
+	if point.Distance(f.Origin) <= f.MaxDistance {
+		return true
+	}
+
+	return false
+}

--- a/pkg/flood/flood_test.go
+++ b/pkg/flood/flood_test.go
@@ -1,0 +1,131 @@
+package flood
+
+import (
+	"testing"
+)
+
+type GenericNode struct {
+	id    string
+	point Point
+}
+
+func (n *GenericNode) ID() string {
+	return n.id
+}
+
+func (n *GenericNode) SetID(id string) {
+	n.id = id
+}
+
+func (n *GenericNode) Point() Point {
+	return n.point
+}
+
+func (n *GenericNode) SetPoint(point Point) {
+	n.point = point
+}
+
+func (n *GenericNode) Clone() Node {
+	nodeCopy := GenericNode{
+		id:    n.id,
+		point: n.point,
+	}
+
+	typeCastedNode := nodeCopy
+
+	return &typeCastedNode
+}
+
+type GenericGrid struct {
+	nodes [][]Node
+}
+
+func (n GenericGrid) Nodes() [][]Node {
+	return n.nodes
+}
+
+func (n GenericGrid) SetNode(x int, y int, node Node) {
+	n.nodes[x][y] = node
+}
+
+// A simple initilizer function to provide a default empty x by x grid state.
+func buildEmptyGrid(width int, height int) [][]Node {
+	nodes := make([][]Node, height)
+
+	for x := 0; x < width; x++ {
+		row := make([]Node, width)
+
+		for y := 0; y < height; y++ {
+			node := GenericNode{}
+			node.SetPoint(Point{x, y})
+			node.SetID("0000")
+
+			row[y] = &node
+		}
+
+		nodes[x] = row
+	}
+
+	return nodes
+}
+
+// A simple initilizer function to provide a default grid with a set of blocked nodes.
+func buildBlockedGrid(width int, height int) [][]Node {
+	nodes := make([][]Node, height)
+
+	for x := 0; x < width; x++ {
+		row := make([]Node, width)
+
+		for y := 0; y < height; y++ {
+			node := GenericNode{}
+			node.SetPoint(Point{x, y})
+			node.SetID("0000")
+
+			// Create an artifical wall here to block flood filling.
+			if x == 2 {
+				node.SetID("0002")
+			}
+
+			row[y] = &node
+		}
+
+		nodes[x] = row
+	}
+
+	return nodes
+}
+
+func TestFill(t *testing.T) {
+	// Test full empty fill
+	grid := GenericGrid{}
+	grid.nodes = buildEmptyGrid(4, 4)
+
+	flood := NewFiller(Point{0, 0}, grid, 8)
+	flood.Fill(Point{0, 0}, "0001", "0002")
+
+	if flood.Grid.Nodes()[0][0].ID() != "0001" {
+		t.Logf("Origin node not filled.")
+		t.Fail()
+	}
+
+	if flood.Grid.Nodes()[3][3].ID() != "0001" {
+		t.Logf("Node not filled.")
+		t.Fail()
+	}
+
+	// Test blocked fill
+	grid = GenericGrid{}
+	grid.nodes = buildBlockedGrid(4, 4)
+	flood = NewFiller(Point{0, 0}, grid, 8)
+	flood.Fill(Point{0, 0}, "0001", "0002")
+
+	if flood.Grid.Nodes()[0][0].ID() != "0001" {
+		t.Logf("Origin node not filled.")
+		t.Fail()
+	}
+
+	if flood.Grid.Nodes()[3][3].ID() != "0000" {
+		t.Logf("Blocking not correctly respected.")
+		t.Fail()
+	}
+}

--- a/pkg/flood/flood_test.go
+++ b/pkg/flood/flood_test.go
@@ -31,9 +31,7 @@ func (n *GenericNode) Clone() Node {
 		point: n.point,
 	}
 
-	typeCastedNode := nodeCopy
-
-	return &typeCastedNode
+	return &nodeCopy
 }
 
 type GenericGrid struct {

--- a/pkg/flood/grid.go
+++ b/pkg/flood/grid.go
@@ -1,0 +1,10 @@
+package flood
+
+// Grid represents a 2D matrix comprised of nodes.
+type Grid interface {
+	//Nodes contains a 2D matrix of nodes that make up this 2D Grid
+	Nodes() [][]Node
+
+	//SetNode Updates a Node at a particular X and Y coordinate in this 2D Grid
+	SetNode(int, int, Node)
+}

--- a/pkg/flood/node.go
+++ b/pkg/flood/node.go
@@ -1,0 +1,19 @@
+package flood
+
+// Node A Node represents a point in a 2D matrix with identifying information
+type Node interface {
+	//ID Returns a valid identifier for this nood to be filled
+	ID() string
+
+	//SetID Sets the ID value of a structure conforming to the Node type
+	SetID(string)
+
+	//Point Returns a pair of cartesian coordinates
+	Point() Point
+
+	//SetPoint Sets the point where this node currently exists
+	SetPoint(Point)
+
+	//Clone Creates a deep copy of this node
+	Clone() Node
+}

--- a/pkg/flood/point.go
+++ b/pkg/flood/point.go
@@ -1,0 +1,33 @@
+package flood
+
+// Point A Point holds a cartesian coordinate pair with x and y as standard integer values.
+type Point struct {
+	X int
+	Y int
+}
+
+// SetX sets the x value of a Point
+func (p *Point) SetX(x int) {
+	p.X = x
+}
+
+// SetY sets the y value of a Point
+func (p *Point) SetY(y int) {
+	p.Y = y
+}
+
+// Distance Calculates the Manhattan distance from this point to a given point in euclidan geometric
+// space and returns it as an integer value.
+func (p *Point) Distance(point Point) int {
+	distance := abs(p.X-point.X) + abs(p.Y-point.Y)
+
+	return distance
+}
+
+// abs calculates the absolute value of an integer
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}


### PR DESCRIPTION
### Introduction

This package is an attempt to service the broader go game development community by providing a generic library that makes it easy to do [flood-filling](https://en.wikipedia.org/wiki/Flood_fill) of a 2D game board.

### Implementation

The [grid.go](pkg/flood/grid.go) and [node.go](pkg/flood/node.go) serve as generic 'ish' interfaces for consumers to supply their own game state into, see the generic examples for more context on both Grid and Node. 

The filler is the basic 4 way flood fill algorithm implementation, there's an argument for allowing for 8 way flood filling but I think we should go back and retroactively add this at a later date.

### Consuming

The example package contains a complete example of how to consume the library by implementing the two different interfaces and then creating an instance of the filler structure.

### Testing

I do some basic testing in this package feel free to read through that mostly just uses the same code in the example implementation.
